### PR TITLE
Create multi-page YouStillMatter support site

### DIFF
--- a/anxiety-awareness.html
+++ b/anxiety-awareness.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anxiety Awareness Hub | YouStillMatter</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <meta
+      name="description"
+      content="Explore the YouStillMatter Anxiety Awareness Hub for grounding exercises, coping strategies, and trusted helplines to help you feel more in control."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="brand" href="index.html">YouStillMatter</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="anxiety-awareness.html" aria-current="page">Anxiety Awareness</a></li>
+            <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
+            <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="page-hero">
+        <p class="breadcrumbs"><a href="index.html">Home</a> › Anxiety Awareness Hub</p>
+        <h1>Anxiety Awareness Hub</h1>
+        <p>
+          Anxiety can feel overwhelming, but you are not alone. We curated evidence-informed guidance, grounding practices, and community resources to support your mind and body in moments of stress.
+        </p>
+        <div class="info-banner">
+          <strong>Need support right now?</strong>
+          <span>Text HOME to 741741 (US/Canada) or message Shout at 85258 (UK) for immediate text-based help.</span>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <article class="content-card">
+          <h2>Understand what you are feeling</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Common signs of anxiety</h3>
+              <ul>
+                <li>Racing thoughts, difficulty focusing, or feeling on-edge.</li>
+                <li>Muscle tension, headaches, or stomach discomfort.</li>
+                <li>Rapid heartbeat, shortness of breath, or lightheadedness.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>When to seek extra support</h3>
+              <ul>
+                <li>Anxiety interferes with work, school, or relationships.</li>
+                <li>You avoid people, places, or experiences you usually enjoy.</li>
+                <li>You have thoughts of self-harm or feel unsafe. Reach out to a professional immediately.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Grounding exercises you can try today</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Five senses reset</h3>
+              <ul>
+                <li>Notice 5 things you can see around you.</li>
+                <li>List 4 things you can touch and describe how they feel.</li>
+                <li>Identify 3 things you can hear, 2 you can smell, and 1 you can taste.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Regulate with breath and body</h3>
+              <ul>
+                <li>Box breathing: inhale, hold, exhale, hold for four counts each.</li>
+                <li>Progressive muscle relaxation: tense and release each muscle group from toes to forehead.</li>
+                <li>Self-compassion pause: place a hand over your heart and say, “This is hard, and I’m doing my best.”</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Resource quick links</h2>
+          <ul class="resource-list">
+            <li><span>Anxiety &amp; Depression Association of America</span> Learn coping tools and connect with support groups.</li>
+            <li><span>National Alliance on Mental Illness</span> Find local education programs and peer-led support.</li>
+            <li><span>Calm Harm App</span> A guided app for reducing the urge to self-harm and practicing calm.</li>
+            <li><span>Headspace &amp; Insight Timer</span> Meditation libraries with free breathing and mindfulness exercises.</li>
+          </ul>
+        </article>
+
+        <article class="content-card">
+          <h2>Create your personal coping plan</h2>
+          <p>
+            Download, print, or screenshot this plan to keep supportive strategies close at hand. Update it when you discover new tools that work for you.
+          </p>
+          <div class="grid-two">
+            <div>
+              <h3>My calm toolkit</h3>
+              <ul>
+                <li>Three people I can text or call when I need reassurance.</li>
+                <li>Two grounding activities that help me reset.</li>
+                <li>One mantra or affirmation that reminds me I am safe.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>My professional support</h3>
+              <ul>
+                <li>Therapist or counselor contact information.</li>
+                <li>Doctor or psychiatrist details for medication questions.</li>
+                <li>Emergency contacts and crisis lines that serve my area.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="year"></span> YouStillMatter. You deserve support every step of the way.</p>
+        <div class="footer-links">
+          <a href="anxiety-awareness.html">Anxiety Support</a>
+          <a href="depression-hope.html">Hope Stories</a>
+          <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="mailto:hello@youstillmatter.org">Contact</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const yearSpan = document.getElementById('year');
+      if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,366 @@
+:root {
+  --brand-primary: #2f80ed;
+  --brand-secondary: #6c5ce7;
+  --brand-accent: #f9a826;
+  --text-dark: #1b1f3b;
+  --text-muted: #4a4a68;
+  --bg-light: #f7f8fc;
+  --bg-gradient: linear-gradient(135deg, rgba(47,128,237,0.15), rgba(108,92,231,0.15));
+  --max-width: 1100px;
+  --radius-lg: 18px;
+  --shadow-soft: 0 20px 45px rgba(36, 56, 99, 0.15);
+  --font-body: 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--text-dark);
+  background: var(--bg-gradient), var(--bg-light);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--brand-primary);
+}
+
+header {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 2px 20px rgba(31, 64, 154, 0.08);
+}
+
+.navbar {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1.2rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--brand-primary);
+}
+
+nav ul {
+  display: flex;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-weight: 500;
+}
+
+nav a {
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--brand-secondary);
+  transform: translateY(-2px);
+}
+
+.hero {
+  max-width: var(--max-width);
+  margin: 4rem auto 3rem;
+  padding: 0 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.2rem, 6vw, 3.4rem);
+  margin: 0 0 1.2rem;
+  color: var(--text-dark);
+}
+
+.hero-content p {
+  font-size: 1.1rem;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.btn {
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(47, 128, 237, 0.35);
+}
+
+.btn-secondary {
+  background: #fff;
+  color: var(--brand-primary);
+  box-shadow: 0 12px 25px rgba(47, 128, 237, 0.18);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+}
+
+.card-grid {
+  max-width: var(--max-width);
+  margin: 0 auto 4rem;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(47, 128, 237, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h3 {
+  margin: 0;
+}
+
+.card p {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.card .link {
+  margin-top: auto;
+  font-weight: 600;
+  color: var(--brand-primary);
+}
+
+.section-title {
+  text-align: center;
+  font-size: 1.9rem;
+  margin: 0 auto 2.5rem;
+  max-width: 700px;
+  color: var(--text-dark);
+}
+
+.split-section {
+  max-width: var(--max-width);
+  margin: 0 auto 4rem;
+  padding: 0 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.highlight-box {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(108, 92, 231, 0.12);
+}
+
+.resource-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.resource-list li {
+  background: rgba(47, 128, 237, 0.08);
+  border-radius: 12px;
+  padding: 0.95rem 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.resource-list li span {
+  font-weight: 600;
+  color: var(--brand-secondary);
+}
+
+footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2.5rem 1.5rem;
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.footer-inner p {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.main-content {
+  max-width: var(--max-width);
+  margin: 3rem auto 4rem;
+  padding: 0 1.5rem;
+}
+
+.page-hero {
+  background: rgba(255, 255, 255, 0.92);
+  padding: 2.8rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.page-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.breadcrumbs {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.content-section {
+  margin-top: 3rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.content-card {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.content-card h2 {
+  margin-top: 0;
+}
+
+.grid-two {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid-two ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.info-banner {
+  background: linear-gradient(135deg, rgba(47,128,237,0.12), rgba(108,92,231,0.12));
+  border: 1px solid rgba(47,128,237,0.2);
+  padding: 1.5rem;
+  border-radius: 16px;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.story-form label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.story-form input,
+.story-form textarea,
+.story-form select {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border 0.2s ease;
+}
+
+.story-form input:focus,
+.story-form textarea:focus,
+.story-form select:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 3px rgba(47, 128, 237, 0.2);
+}
+
+.story-form textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.alert-box {
+  background: rgba(249, 168, 38, 0.14);
+  border-left: 4px solid var(--brand-accent);
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  color: #8a5a02;
+}
+
+@media (max-width: 640px) {
+  .navbar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero-actions {
+    justify-content: center;
+  }
+}

--- a/depression-hope.html
+++ b/depression-hope.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Depression &amp; Hope Stories | YouStillMatter</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <meta
+      name="description"
+      content="Read anonymous stories of hope, learn practical coping strategies, and submit your experience to uplift others in the YouStillMatter community."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="brand" href="index.html">YouStillMatter</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
+            <li><a href="depression-hope.html" aria-current="page">Depression & Hope Stories</a></li>
+            <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="page-hero">
+        <p class="breadcrumbs"><a href="index.html">Home</a> › Depression &amp; Hope Stories</p>
+        <h1>Stories of Hope Through Depression</h1>
+        <p>
+          Healing isn’t linear. By sharing honest reflections, we remind one another that hope can return in small, steady moments. Explore uplifting stories and submit your own experience anonymously to inspire others.
+        </p>
+        <div class="info-banner">
+          <strong>You are not alone.</strong>
+          <span>Reach the 988 Suicide &amp; Crisis Lifeline (US) or find local crisis numbers at <a href="https://www.opencounseling.com/suicide-hotlines" target="_blank" rel="noopener">Open Counseling</a>.</span>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <article class="content-card">
+          <h2>Spotlight stories from our community</h2>
+          <div class="grid-two">
+            <blockquote>
+              “There were months where getting out of bed felt impossible. A friend kept texting me, even when I didn’t respond. Those small reminders helped me reach out for therapy. Today I celebrate every little win.”
+              <footer>— Community Member, Age 26</footer>
+            </blockquote>
+            <blockquote>
+              “Depression told me I was alone. Volunteering at a local shelter gave me a purpose for a few hours each week. It didn’t cure everything, but it gave me connection. That was the first step back to hope.”
+              <footer>— Community Member, Age 41</footer>
+            </blockquote>
+          </div>
+          <p class="alert-box">
+            These stories are shared with permission and edited for privacy. They are not a substitute for professional guidance but can remind us that recovery takes many forms.
+          </p>
+        </article>
+
+        <article class="content-card">
+          <h2>Submit your anonymous story</h2>
+          <p>
+            Your journey matters. Complete the form below to offer encouragement to someone who might need it today. Submissions are reviewed before appearing on the site to maintain safety and compassion.
+          </p>
+          <form class="story-form" action="#" method="post">
+            <label for="story-theme">Which theme fits your story?</label>
+            <select id="story-theme" name="theme" required>
+              <option value="" disabled selected>Select a theme</option>
+              <option value="first-steps">Taking first steps toward help</option>
+              <option value="setbacks">Navigating setbacks</option>
+              <option value="support">Finding support in community</option>
+              <option value="self-kindness">Practicing self-kindness</option>
+            </select>
+
+            <label for="story-text">Share your experience</label>
+            <textarea id="story-text" name="story" placeholder="What has helped you keep going?" required></textarea>
+
+            <label for="story-tip">What advice or affirmation would you offer someone reading?</label>
+            <input id="story-tip" name="tip" type="text" placeholder="e.g., Remember to celebrate the tiniest victories." required />
+
+            <button class="btn btn-primary" type="submit">Submit my story</button>
+          </form>
+        </article>
+
+        <article class="content-card">
+          <h2>Practical steps to nurture hope</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Routines that restore</h3>
+              <ul>
+                <li>Create a simple morning or evening ritual that signals care for yourself.</li>
+                <li>Schedule one “connection point” each week with someone you trust.</li>
+                <li>Track your mood gently to notice what environments help you feel safer.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Professional &amp; peer support</h3>
+              <ul>
+                <li>Ask your doctor about integrated care options or low-cost therapy programs.</li>
+                <li>Join a peer-led support group through NAMI, DBSA, or local community centers.</li>
+                <li>Explore virtual therapy platforms that offer sliding scale pricing.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="year"></span> YouStillMatter. Thank you for helping others feel less alone.</p>
+        <div class="footer-links">
+          <a href="anxiety-awareness.html">Anxiety Support</a>
+          <a href="depression-hope.html">Hope Stories</a>
+          <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="mailto:hello@youstillmatter.org">Contact</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const yearSpan = document.getElementById('year');
+      if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>YouStillMatter | Mental Health Support & Resources</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <meta
+      name="description"
+      content="YouStillMatter is a compassionate hub offering mental health resources, coping strategies, and real stories of resilience for youth and adults."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="brand" href="index.html">YouStillMatter</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
+            <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
+            <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
 
+    <main>
+      <section class="hero">
+        <div class="hero-content">
+          <p class="breadcrumbs">Because your story, your voice, and your future matter.</p>
+          <h1>Welcoming you to the YouStillMatter community</h1>
+          <p>
+            Our mission is to provide an uplifting space that honors your experiences and equips you with practical tools to thrive. Explore our tailored resources on anxiety, discover inspiring stories of hope through depression, and find school-ready supports designed for young people.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="anxiety-awareness.html">Explore anxiety support</a>
+            <a class="btn btn-secondary" href="depression-hope.html">Read hope stories</a>
+          </div>
+        </div>
+        <div class="highlight-box">
+          <h2>How we stand beside you</h2>
+          <ul class="resource-list">
+            <li>
+              <span>Personalized paths</span>
+              Navigate resources curated for your stage of life and needs.
+            </li>
+            <li>
+              <span>Community stories</span>
+              Read and share experiences anonymously to connect with others.
+            </li>
+            <li>
+              <span>Trusted guidance</span>
+              Evidence-informed strategies from mental health educators and advocates.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="section-title">Choose a supportive space crafted for you</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Anxiety Awareness Hub</h3>
+            <p>
+              Understand anxiety, practice grounding exercises, and discover crisis support lines and chat services that are ready to listen day or night.
+            </p>
+            <a class="link" href="anxiety-awareness.html">Visit the hub →</a>
+          </article>
+
+          <article class="card">
+            <h3>Depression &amp; Hope Stories</h3>
+            <p>
+              Read encouraging stories from peers, submit your own anonymously, and explore practical steps for reaching out when life feels heavy.
+            </p>
+            <a class="link" href="depression-hope.html">Find inspiration →</a>
+          </article>
+
+          <article class="card">
+            <h3>Youth Mental Health Toolkit</h3>
+            <p>
+              Give students and school communities a toolkit of lesson plans, check-in activities, and support hotlines to nurture well-being.
+            </p>
+            <a class="link" href="youth-mental-health.html">Equip your classroom →</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="split-section">
+        <div class="content-card">
+          <h2>Immediate help is always within reach</h2>
+          <p>
+            If you or someone you know is in immediate danger, please call local emergency services right away. The resources shared here are informative and supportive, but they do not replace professional care.
+          </p>
+          <div class="info-banner">
+            <strong>24/7 Hotlines &amp; Chats</strong>
+            <span>United States: 988 Suicide &amp; Crisis Lifeline • Crisis Text Line: Text HOME to 741741</span>
+            <span>Canada: 988 Suicide Crisis Helpline • Kids Help Phone: Text CONNECT to 686868</span>
+            <span>UK &amp; Ireland: Samaritans 116 123 • Shout Crisis Text Line: Text SHOUT to 85258</span>
+          </div>
+        </div>
+        <div class="content-card">
+          <h2>How to use YouStillMatter</h2>
+          <ul>
+            <li>Start with the topic that speaks to your current experience.</li>
+            <li>Save or print the checklists and grounding tools you find useful.</li>
+            <li>Share the youth toolkit with educators, parents, and caregivers in your network.</li>
+            <li>Submit a story of hope or resilience to encourage someone else.</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="year"></span> YouStillMatter. Built with compassion to remind you that you are never alone.</p>
+        <div class="footer-links">
+          <a href="anxiety-awareness.html">Anxiety Support</a>
+          <a href="depression-hope.html">Hope Stories</a>
+          <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="mailto:hello@youstillmatter.org">Contact</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const yearSpan = document.getElementById('year');
+      if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/youth-mental-health.html
+++ b/youth-mental-health.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Youth Mental Health Toolkit | YouStillMatter</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <meta
+      name="description"
+      content="Download lesson ideas, student check-ins, and family conversation starters with the YouStillMatter Youth Mental Health Toolkit."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="brand" href="index.html">YouStillMatter</a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
+            <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
+            <li><a href="youth-mental-health.html" aria-current="page">Youth Toolkit</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="page-hero">
+        <p class="breadcrumbs"><a href="index.html">Home</a> › Youth Mental Health Toolkit</p>
+        <h1>Youth Mental Health Toolkit</h1>
+        <p>
+          Students and young people thrive when their well-being is centered. This toolkit equips educators, caregivers, and youth leaders with ready-to-use supports that nurture resilience and open conversations.
+        </p>
+        <div class="info-banner">
+          <strong>Who is this for?</strong>
+          <span>Middle &amp; high school classrooms • Student clubs • Counselors • Parent &amp; caregiver groups</span>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <article class="content-card">
+          <h2>Classroom-ready resources</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Lesson sparks</h3>
+              <ul>
+                <li>“Feelings vocabulary” warm-up with emotion cards or digital polls.</li>
+                <li>Resilience timeline activity for students to map past wins.</li>
+                <li>Mindful movement break guide for 5-minute resets.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Printable supports</h3>
+              <ul>
+                <li>Weekly mood tracker with check-in prompts.</li>
+                <li>Self-care menu poster highlighting low-cost ideas.</li>
+                <li>Peer support agreement template for student leaders.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Student voice spotlight</h2>
+          <p>
+            Invite students to share perspectives and shape the supports they want to see. Their insights are vital for building a culture of care.
+          </p>
+          <div class="grid-two">
+            <div>
+              <h3>Conversation starters</h3>
+              <ul>
+                <li>“What helps you feel safe speaking up in class?”</li>
+                <li>“How can adults show they are listening without judgment?”</li>
+                <li>“What is one change that would make school feel more supportive?”</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Leadership ideas</h3>
+              <ul>
+                <li>Host monthly student-led wellness circles.</li>
+                <li>Create a peer ambassador program for new students.</li>
+                <li>Collaborate with art or music classes for mental health awareness campaigns.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Family &amp; caregiver connections</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Tools for home</h3>
+              <ul>
+                <li>Weekly check-in questions to prompt open conversations.</li>
+                <li>Family calming corner checklist with sensory-friendly items.</li>
+                <li>Guide to co-creating a support plan with your teen.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Community partners</h3>
+              <ul>
+                <li>Local youth crisis centers and after-school programs.</li>
+                <li>Parent support groups through NAMI or YMCA chapters.</li>
+                <li>School-based health clinics with mental health providers.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Emergency &amp; ongoing support</h2>
+          <p class="alert-box">
+            If a young person is in immediate danger, contact emergency services. Use the resources below for crisis and ongoing mental health support.
+          </p>
+          <ul class="resource-list">
+            <li><span>988 Suicide &amp; Crisis Lifeline (US)</span> Call or text 988 for round-the-clock support.</li>
+            <li><span>National Text Line</span> Text HOME to 741741 for free crisis counseling.</li>
+            <li><span>Teen Line (US)</span> Call (800) 852-8336 or text TEEN to 839863 every evening.</li>
+            <li><span>Kids Help Phone (Canada)</span> Call 1-800-668-6868 or text CONNECT to 686868.</li>
+            <li><span>Childline (UK &amp; Ireland)</span> Call 0800 1111 or chat online at childline.org.uk.</li>
+          </ul>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="year"></span> YouStillMatter. Empowering youth to know they are never alone.</p>
+        <div class="footer-links">
+          <a href="anxiety-awareness.html">Anxiety Support</a>
+          <a href="depression-hope.html">Hope Stories</a>
+          <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="mailto:hello@youstillmatter.org">Contact</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const yearSpan = document.getElementById('year');
+      if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- design a refreshed YouStillMatter homepage with branded navigation, hero content, and quick links to key support areas
- add dedicated pages for anxiety awareness, depression hope stories, and the youth mental health toolkit with actionable guidance and resources
- create a shared stylesheet to provide cohesive styling, layout utilities, and accessible call-to-action components across the site

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce4f9833ec83339e44c13cceb60d1f