### PR TITLE
Refine mood tracker PDF layout and add print control

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -188,6 +188,14 @@ nav a:focus {
   color: var(--brand-primary);
 }
 
+.resource-cta {
+  margin-top: 1.5rem;
+}
+
+.resource-cta .btn {
+  font-size: 0.95rem;
+}
+
 .section-title {
   text-align: center;
   font-size: 1.9rem;

--- a/assets/mood-tracker-checkin.pdf
+++ b/assets/mood-tracker-checkin.pdf
@@ -1,0 +1,443 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+2 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /ZapfDingbats >>
+endobj
+5 0 obj
+<< /Length 3842 >>
+stream
+1 w
+0 0 0 rg
+0 0 0 RG
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 700 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 660 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 620 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 580 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 540 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 500 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 460 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 420 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 380 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 340 20 20 re S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+36 300 20 20 re S
+0 0 0 RG
+0 0 0 rg
+BT /F3 34 Tf 72 722 Td (Mental health check in) Tj ET
+BT /F2 11 Tf 360 678 Td (DATE) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+360 646 180 28 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 72 634 Td (HOW ARE YOU FEELING TODAY?) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+72 496 228 126 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 72 472 Td (HOW ARE YOU FEELING TODAY?) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+72 414 228 58 re B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+0.98 0.98 0.98 rg
+n
+96 457 m
+103.73 457 110 450.73 110 443 c
+110 435.27 103.73 429 96 429 c
+88.27 429 82 435.27 82 443 c
+82 450.73 88.27 457 96 457 c
+B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+0.98 0.98 0.98 rg
+n
+140 457 m
+147.73 457 154 450.73 154 443 c
+154 435.27 147.73 429 140 429 c
+132.27 429 126 435.27 126 443 c
+126 450.73 132.27 457 140 457 c
+B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+0.98 0.98 0.98 rg
+n
+184 457 m
+191.73 457 198 450.73 198 443 c
+198 435.27 191.73 429 184 429 c
+176.27 429 170 435.27 170 443 c
+170 450.73 176.27 457 184 457 c
+B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+0.98 0.98 0.98 rg
+n
+228 457 m
+235.73 457 242 450.73 242 443 c
+242 435.27 235.73 429 228 429 c
+220.27 429 214 435.27 214 443 c
+214 450.73 220.27 457 228 457 c
+B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+0.98 0.98 0.98 rg
+n
+272 457 m
+279.73 457 286 450.73 286 443 c
+286 435.27 279.73 429 272 429 c
+264.27 429 258 435.27 258 443 c
+258 450.73 264.27 457 272 457 c
+B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 72 392 Td (HOW CAN YOU IMPROVE YOUR MENTAL HEALTH?) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+72 282 228 106 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 320 634 Td (WHAT HAVE BEEN YOUR THREE DOMINANT EMOTIONS THIS WEEK?) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+320 496 220 126 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 320 472 Td (WHAT DO YOU FEEL GOOD ABOUT RIGHT NOW?) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+320 414 220 58 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 320 392 Td (THINGS THAT TRIGGER NEGATIVE EMOTIONS) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+320 332 220 74 re B
+0 0 0 RG
+0 0 0 rg
+BT /F2 11 Tf 320 310 Td (MY RANKING OF MY MENTAL HEALTH THIS WEEK) Tj ET
+0.83 0.83 0.83 RG
+0.96 0.96 0.96 rg
+320 270 220 50 re B
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+350 310 m
+353.53 300.85 l
+363.31 300.33 l
+355.71 294.15 l
+358.23 284.67 l
+350 290 l
+341.77 284.67 l
+344.29 294.15 l
+336.69 300.33 l
+346.47 300.85 l
+h
+S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+386 310 m
+389.53 300.85 l
+399.31 300.33 l
+391.71 294.15 l
+394.23 284.67 l
+386 290 l
+377.77 284.67 l
+380.29 294.15 l
+372.69 300.33 l
+382.47 300.85 l
+h
+S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+422 310 m
+425.53 300.85 l
+435.31 300.33 l
+427.71 294.15 l
+430.23 284.67 l
+422 290 l
+413.77 284.67 l
+416.29 294.15 l
+408.69 300.33 l
+418.47 300.85 l
+h
+S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+458 310 m
+461.53 300.85 l
+471.31 300.33 l
+463.71 294.15 l
+466.23 284.67 l
+458 290 l
+449.77 284.67 l
+452.29 294.15 l
+444.69 300.33 l
+454.47 300.85 l
+h
+S
+0 0 0 RG
+0 0 0 rg
+0.75 0.75 0.75 RG
+1 1 1 rg
+494 310 m
+497.53 300.85 l
+507.31 300.33 l
+499.71 294.15 l
+502.23 284.67 l
+494 290 l
+485.77 284.67 l
+488.29 294.15 l
+480.69 300.33 l
+490.47 300.85 l
+h
+S
+0 0 0 RG
+0 0 0 rg
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 7 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 1 0 R /F2 2 0 R /F3 3 0 R /F4 4 0 R >> >> /Contents 5 0 R /Annots [10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R] >>
+endobj
+7 0 obj
+<< /Type /Pages /Kids [6 0 R] /Count 1 >>
+endobj
+8 0 obj
+<< /Fields [10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R] /DA (/F1 11 Tf 0 g) /NeedAppearances true /DR << /Font << /F1 1 0 R /F2 2 0 R /F3 3 0 R /F4 4 0 R >> >> >>
+endobj
+9 0 obj
+<< /Type /Catalog /Pages 7 0 R /AcroForm 8 0 R >>
+endobj
+10 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [368 650 532 670]
+/FT /Tx
+/T (Date)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 0
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+11 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [78 504 294 612]
+/FT /Tx
+/T (FeelingSummary)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 4096
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+12 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [78 444 294 468]
+/FT /Tx
+/T (FeelingEmoji)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 0
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+13 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [78 292 294 382]
+/FT /Tx
+/T (ImproveMentalHealth)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 4096
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+14 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [326 504 532 612]
+/FT /Tx
+/T (DominantEmotions)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 4096
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+15 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [326 422 532 464]
+/FT /Tx
+/T (FeelGood)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 4096
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+16 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [326 338 532 396]
+/FT /Tx
+/T (Triggers)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 4096
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+17 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [326 304 532 320]
+/FT /Tx
+/T (WeeklyRanking)
+/F 4
+/P 6 0 R
+/DA (/F1 11 Tf 0 g)
+/MK <<>>
+/Ff 0
+/BS << /W 0 >>
+/V ()
+>>
+endobj
+18 0 obj
+<<
+/Type /Annot
+/Subtype /Widget
+/Rect [456 724 572 748]
+/FT /Btn
+/T (PrintForm)
+/F 4
+/P 6 0 R
+/DA (/F1 12 Tf 0 g)
+/MK << /CA (Print form) /BG [0.88 0.91 0.96] /BC [0.56 0.63 0.78] >>
+/Ff 65536
+/BS << /W 1 /S /S >>
+/A << /S /JavaScript /JS (this.print\\(true\\);) >>
+>>
+endobj
+xref
+0 19
+0000000000 65535 f 
+0000000015 00000 n 
+0000000085 00000 n 
+0000000160 00000 n 
+0000000238 00000 n 
+0000000311 00000 n 
+0000004205 00000 n 
+0000004434 00000 n 
+0000004491 00000 n 
+0000004689 00000 n 
+0000004754 00000 n 
+0000004918 00000 n 
+0000005094 00000 n 
+0000005265 00000 n 
+0000005446 00000 n 
+0000005625 00000 n 
+0000005796 00000 n 
+0000005967 00000 n 
+0000006140 00000 n 
+trailer
+<< /Size 19 /Root 9 0 R >>
+startxref
+6426
+%%EOF

--- a/generate_mood_tracker_pdf.py
+++ b/generate_mood_tracker_pdf.py
@@ -1,0 +1,252 @@
+import math
+from collections import OrderedDict
+
+
+def escape_pdf_text(text: str) -> str:
+    return text.replace("\\", r"\\\\").replace("(", r"\\(").replace(")", r"\\)")
+
+
+objects: list[str] = []
+
+
+def add_object(content: str) -> int:
+    objects.append(content)
+    return len(objects)
+
+
+font_objects = OrderedDict(
+    {
+        "F1": add_object("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+        "F2": add_object("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"),
+        "F3": add_object("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Oblique >>"),
+        "F4": add_object("<< /Type /Font /Subtype /Type1 /BaseFont /ZapfDingbats >>"),
+    }
+)
+
+content_lines: list[str] = []
+content_lines.append("1 w")
+content_lines.append("0 0 0 rg")
+content_lines.append("0 0 0 RG")
+
+
+def fmt(value: float) -> str:
+    return f"{value:.2f}".rstrip("0").rstrip(".") if not float(value).is_integer() else str(int(value))
+
+
+def draw_soft_rect(x: float, y: float, w: float, h: float) -> None:
+    content_lines.extend(
+        [
+            "0.83 0.83 0.83 RG",
+            "0.96 0.96 0.96 rg",
+            f"{fmt(x)} {fmt(y)} {fmt(w)} {fmt(h)} re B",
+            "0 0 0 RG",
+            "0 0 0 rg",
+        ]
+    )
+
+
+def draw_checkbox(x: float, y: float, size: float) -> None:
+    content_lines.extend(
+        [
+            "0.75 0.75 0.75 RG",
+            "1 1 1 rg",
+            f"{fmt(x)} {fmt(y)} {fmt(size)} {fmt(size)} re S",
+            "0 0 0 RG",
+            "0 0 0 rg",
+        ]
+    )
+
+
+def draw_circle(cx: float, cy: float, radius: float) -> None:
+    c = 0.5522847498 * radius
+    content_lines.extend(
+        [
+            "0.75 0.75 0.75 RG",
+            "0.98 0.98 0.98 rg",
+            "n",
+            f"{fmt(cx)} {fmt(cy + radius)} m",
+            f"{fmt(cx + c)} {fmt(cy + radius)} {fmt(cx + radius)} {fmt(cy + c)} {fmt(cx + radius)} {fmt(cy)} c",
+            f"{fmt(cx + radius)} {fmt(cy - c)} {fmt(cx + c)} {fmt(cy - radius)} {fmt(cx)} {fmt(cy - radius)} c",
+            f"{fmt(cx - c)} {fmt(cy - radius)} {fmt(cx - radius)} {fmt(cy - c)} {fmt(cx - radius)} {fmt(cy)} c",
+            f"{fmt(cx - radius)} {fmt(cy + c)} {fmt(cx - c)} {fmt(cy + radius)} {fmt(cx)} {fmt(cy + radius)} c",
+            "B",
+            "0 0 0 RG",
+            "0 0 0 rg",
+        ]
+    )
+
+
+def draw_star(cx: float, cy: float, outer_r: float, inner_r: float) -> None:
+    points: list[tuple[float, float]] = []
+    for i in range(10):
+        angle = math.radians(90 - i * 36)
+        radius = outer_r if i % 2 == 0 else inner_r
+        points.append((cx + radius * math.cos(angle), cy + radius * math.sin(angle)))
+
+    content_lines.extend([
+        "0.75 0.75 0.75 RG",
+        "1 1 1 rg",
+        f"{fmt(points[0][0])} {fmt(points[0][1])} m",
+    ])
+    for x, y in points[1:]:
+        content_lines.append(f"{fmt(x)} {fmt(y)} l")
+    content_lines.extend(["h", "S", "0 0 0 RG", "0 0 0 rg"])
+
+
+def add_text(font_ref: str, size: float, x: float, y: float, text: str) -> None:
+    content_lines.append(
+        f"BT /{font_ref} {fmt(size)} Tf {fmt(x)} {fmt(y)} Td ({escape_pdf_text(text)}) Tj ET"
+    )
+
+
+checkbox_x = 36
+checkbox_top = 700
+checkbox_size = 20
+for index in range(11):
+    draw_checkbox(checkbox_x, checkbox_top - index * 40, checkbox_size)
+
+add_text("F3", 34, 72, 722, "Mental health check in")
+add_text("F2", 11, 360, 678, "DATE")
+draw_soft_rect(360, 646, 180, 28)
+
+add_text("F2", 11, 72, 634, "HOW ARE YOU FEELING TODAY?")
+draw_soft_rect(72, 496, 228, 126)
+
+add_text("F2", 11, 72, 472, "HOW ARE YOU FEELING TODAY?")
+draw_soft_rect(72, 414, 228, 58)
+for offset in range(5):
+    draw_circle(96 + offset * 44, 443, 14)
+
+add_text("F2", 11, 72, 392, "HOW CAN YOU IMPROVE YOUR MENTAL HEALTH?")
+draw_soft_rect(72, 282, 228, 106)
+
+add_text("F2", 11, 320, 634, "WHAT HAVE BEEN YOUR THREE DOMINANT EMOTIONS THIS WEEK?")
+draw_soft_rect(320, 496, 220, 126)
+
+add_text("F2", 11, 320, 472, "WHAT DO YOU FEEL GOOD ABOUT RIGHT NOW?")
+draw_soft_rect(320, 414, 220, 58)
+
+add_text("F2", 11, 320, 392, "THINGS THAT TRIGGER NEGATIVE EMOTIONS")
+draw_soft_rect(320, 332, 220, 74)
+
+add_text("F2", 11, 320, 310, "MY RANKING OF MY MENTAL HEALTH THIS WEEK")
+draw_soft_rect(320, 270, 220, 50)
+for offset in range(5):
+    draw_star(350 + offset * 36, 296, 14, 6)
+
+content_stream = "\n".join(content_lines)
+stream_obj = f"<< /Length {len(content_stream)} >>\nstream\n{content_stream}\nendstream"
+stream_obj_num = add_object(stream_obj)
+
+# Placeholder for page object so we can reference its number in annotations
+page_obj_num = add_object("<<>>")
+
+pages_obj_num = add_object("<<>>")
+acroform_obj_num = add_object("<<>>")
+catalog_obj_num = add_object(
+    f"<< /Type /Catalog /Pages {pages_obj_num} 0 R /AcroForm {acroform_obj_num} 0 R >>"
+)
+
+form_fields = [
+    {"type": "text", "name": "Date", "rect": [368, 650, 532, 670], "multiline": False},
+    {"type": "text", "name": "FeelingSummary", "rect": [78, 504, 294, 612], "multiline": True},
+    {"type": "text", "name": "FeelingEmoji", "rect": [78, 444, 294, 468], "multiline": False},
+    {"type": "text", "name": "ImproveMentalHealth", "rect": [78, 292, 294, 382], "multiline": True},
+    {"type": "text", "name": "DominantEmotions", "rect": [326, 504, 532, 612], "multiline": True},
+    {"type": "text", "name": "FeelGood", "rect": [326, 422, 532, 464], "multiline": True},
+    {"type": "text", "name": "Triggers", "rect": [326, 338, 532, 396], "multiline": True},
+    {"type": "text", "name": "WeeklyRanking", "rect": [326, 304, 532, 320], "multiline": False},
+    {
+        "type": "button",
+        "name": "PrintForm",
+        "rect": [456, 724, 572, 748],
+        "caption": "Print form",
+    },
+]
+
+annotation_obj_nums: list[int] = []
+for field in form_fields:
+    rect_values = " ".join(fmt(value) for value in field["rect"])
+    if field["type"] == "text":
+        flags = 4096 if field.get("multiline") else 0
+        parts = [
+            "<<",
+            "/Type /Annot",
+            "/Subtype /Widget",
+            f"/Rect [{rect_values}]",
+            "/FT /Tx",
+            f"/T ({escape_pdf_text(field['name'])})",
+            "/F 4",
+            f"/P {page_obj_num} 0 R",
+            "/DA (/F1 11 Tf 0 g)",
+            "/MK <<>>",
+            f"/Ff {flags}",
+            "/BS << /W 0 >>",
+            "/V ()",
+            ">>",
+        ]
+    else:
+        caption = escape_pdf_text(field["caption"])
+        js_code = escape_pdf_text("this.print(true);")
+        parts = [
+            "<<",
+            "/Type /Annot",
+            "/Subtype /Widget",
+            f"/Rect [{rect_values}]",
+            "/FT /Btn",
+            f"/T ({escape_pdf_text(field['name'])})",
+            "/F 4",
+            f"/P {page_obj_num} 0 R",
+            "/DA (/F1 12 Tf 0 g)",
+            f"/MK << /CA ({caption}) /BG [0.88 0.91 0.96] /BC [0.56 0.63 0.78] >>",
+            "/Ff 65536",
+            "/BS << /W 1 /S /S >>",
+            f"/A << /S /JavaScript /JS ({js_code}) >>",
+            ">>",
+        ]
+    annotation_obj_nums.append(add_object("\n".join(parts)))
+
+font_resource_entries = " ".join(f"/{name} {obj_num} 0 R" for name, obj_num in font_objects.items())
+annots_array = "[" + " ".join(f"{num} 0 R" for num in annotation_obj_nums) + "]"
+
+page_dict = (
+    f"<< /Type /Page /Parent {pages_obj_num} 0 R /MediaBox [0 0 612 792] "
+    f"/Resources << /Font << {font_resource_entries} >> >> "
+    f"/Contents {stream_obj_num} 0 R /Annots {annots_array} >>"
+)
+objects[page_obj_num - 1] = page_dict
+
+pages_dict = f"<< /Type /Pages /Kids [{page_obj_num} 0 R] /Count 1 >>"
+objects[pages_obj_num - 1] = pages_dict
+
+fields_array = "[" + " ".join(f"{num} 0 R" for num in annotation_obj_nums) + "]"
+acroform_dict = (
+    f"<< /Fields {fields_array} /DA (/F1 11 Tf 0 g) "
+    f"/NeedAppearances true /DR << /Font << {font_resource_entries} >> >> >>"
+)
+objects[acroform_obj_num - 1] = acroform_dict
+
+pdf_header = "%PDF-1.4\n%âãÏÓ\n"
+body_entries = []
+for index, content in enumerate(objects, start=1):
+    body_entries.append(f"{index} 0 obj\n{content}\nendobj\n")
+
+pdf_body_content = "".join(body_entries)
+position = len(pdf_header)
+offsets = []
+for entry in body_entries:
+    offsets.append(position)
+    position += len(entry)
+
+xref_start = position
+xref_lines = [f"xref\n0 {len(objects) + 1}\n0000000000 65535 f \n"]
+for offset in offsets:
+    xref_lines.append(f"{offset:010d} 00000 n \n")
+xref_section = "".join(xref_lines)
+trailer = f"trailer\n<< /Size {len(objects) + 1} /Root {catalog_obj_num} 0 R >>\nstartxref\n{xref_start}\n%%EOF\n"
+
+with open("assets/mood-tracker-checkin.pdf", "wb") as pdf_file:
+    pdf_file.write(pdf_header.encode("latin-1"))
+    pdf_file.write(pdf_body_content.encode("latin-1"))
+    pdf_file.write(xref_section.encode("latin-1"))
+    pdf_file.write(trailer.encode("latin-1"))

--- a/youth-mental-health.html
+++ b/youth-mental-health.html
@@ -62,6 +62,16 @@
                 <li>Self-care menu poster highlighting low-cost ideas.</li>
                 <li>Peer support agreement template for student leaders.</li>
               </ul>
+              <div class="resource-cta">
+                <a
+                  class="btn btn-primary"
+                  href="assets/mood-tracker-checkin.pdf"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  Download fillable mood tracker &amp; check-in
+                </a>
+              </div>
             </div>
           </div>
         </article>


### PR DESCRIPTION
## Summary
- redraw the mood tracker layout directly in the generator so the boxes, labels, and decorative elements mirror the original design
- wire up slim, borderless text fields that sit within each prompt and add a push-button that triggers the PDF print dialog
- regenerate the exported mood tracker PDF asset with the refreshed layout and interactive controls

## Testing
- python -m compileall generate_mood_tracker_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f27e8f7c8333834f02bb2a112707