### PR TITLE
Add marketing page for YouStillMatter app

### DIFF
--- a/anxiety-awareness.html
+++ b/anxiety-awareness.html
@@ -25,6 +25,7 @@
             <li><a href="anxiety-awareness.html" aria-current="page">Anxiety Awareness</a></li>
             <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
             <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+            <li><a href="app.html">Mobile App</a></li>
           </ul>
         </nav>
       </div>
@@ -132,6 +133,7 @@
           <a href="anxiety-awareness.html">Anxiety Support</a>
           <a href="depression-hope.html">Hope Stories</a>
           <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="app.html">Mobile App</a>
           <a href="mailto:hello@youstillmatter.org">Contact</a>
         </div>
       </div>

--- a/app.html
+++ b/app.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>YouStillMatter App | Calm Tools & Crisis Resources</title>
+    <link rel="icon" type="image/svg+xml" href="assets/YouStillMatter.svg" />
+    <link rel="alternate icon" href="assets/YouStillMatter.png" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <meta
+      name="description"
+      content="Discover the YouStillMatter mobile app offering calm tools, crisis resources, and daily emotional support to help you feel grounded and connected."
+    />
+  </head>
+  <body>
+    <header>
+      <div class="navbar">
+        <a class="brand" href="index.html">
+          <img class="brand-mark" src="assets/YouStillMatter.svg" alt="YouStillMatter logo" />
+          <span>YouStillMatter</span>
+        </a>
+        <nav>
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
+            <li><a href="depression-hope.html">Depression &amp; Hope Stories</a></li>
+            <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+            <li><a href="app.html" aria-current="page">Mobile App</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main class="main-content">
+      <section class="page-hero">
+        <p class="breadcrumbs"><a href="index.html">Home</a> › YouStillMatter App</p>
+        <h1>YouStillMatter App</h1>
+        <p><strong>Calm tools and crisis resources</strong></p>
+        <p>
+          Carry a compassionate companion everywhere you go. The YouStillMatter app brings grounding exercises, daily emotional
+          check-ins, and immediate crisis connections together so you can steady your mind and reach help the moment you need it.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="#download">Join the waitlist</a>
+          <a class="btn btn-secondary" href="#features">See everything inside</a>
+        </div>
+        <div class="info-banner">
+          <strong>Why download the app?</strong>
+          <span>Personalized calm plans that update with your mood.</span>
+          <span>One-tap access to crisis lifelines, text lines, and local resources.</span>
+          <span>Daily encouragement rooted in community stories of hope.</span>
+        </div>
+      </section>
+
+      <section id="features" class="content-section">
+        <article class="content-card">
+          <h2>Feel grounded anywhere</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Guided calm tools</h3>
+              <ul>
+                <li>Breathing, grounding, and sensory resets tailored to how you are feeling.</li>
+                <li>Quick-read instructions plus audio walk-throughs for when focus is hard.</li>
+                <li>Save your favorite tools for offline use when Wi-Fi or data is limited.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Mood-aware reminders</h3>
+              <ul>
+                <li>Set gentle reminders to pause, hydrate, move, or message a trusted contact.</li>
+                <li>Receive supportive nudges after difficult days or milestone achievements.</li>
+                <li>Track patterns with weekly reflections designed for you and your counselor.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Immediate crisis support</h2>
+          <div class="grid-two">
+            <div>
+              <h3>24/7 lifelines in one place</h3>
+              <ul>
+                <li>Call, text, or chat with national crisis teams including 988, Crisis Text Line, and SAMHSA.</li>
+                <li>Curated helplines for LGBTQ+, BIPOC, youth, and caregiver communities.</li>
+                <li>Geo-aware suggestions to surface local warm lines, shelters, and health clinics.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Safety planning made simple</h3>
+              <ul>
+                <li>Store coping steps, emergency contacts, and medication details securely on your device.</li>
+                <li>Share a safety plan PDF with loved ones or providers in seconds.</li>
+                <li>Automatic reminders to review and update your plan every season.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="content-card">
+          <h2>Community encouragement</h2>
+          <div class="grid-two">
+            <div>
+              <h3>Stories that reflect your journey</h3>
+              <ul>
+                <li>Read real stories submitted through the YouStillMatter platform to remember you are not alone.</li>
+                <li>Bookmark the words that resonate and return whenever you need encouragement.</li>
+                <li>Submit your own story anonymously to inspire someone else on their path.</li>
+              </ul>
+            </div>
+            <div>
+              <h3>Support circles</h3>
+              <ul>
+                <li>Create a private circle with friends, family, or mentors to share check-ins securely.</li>
+                <li>Send gentle "thinking of you" messages or practical offers of help.</li>
+                <li>Set shared goals—like weekly walks or therapy sessions—to celebrate progress together.</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article id="download" class="content-card">
+          <h2>Be the first to know when we launch</h2>
+          <p>
+            We are building the YouStillMatter app with mental health advocates, youth advisors, and clinicians to ensure every
+            feature feels supportive, trauma-informed, and inclusive. Add yourself to the waitlist to receive launch updates,
+            early access invitations, and printable calm tools you can use today.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="mailto:app@youstillmatter.org?subject=Join%20the%20YouStillMatter%20App%20Waitlist">Email to join</a>
+            <a class="btn btn-secondary" href="anxiety-awareness.html">Explore current resources</a>
+          </div>
+          <div class="info-banner">
+            <strong>Need help right now?</strong>
+            <span>United States: Call or text 988 • Text HOME to 741741 for Crisis Text Line.</span>
+            <span>Canada: Call or text 988 • Text CONNECT to 686868 for Kids Help Phone.</span>
+            <span>UK &amp; Ireland: Samaritans 116 123 • Text SHOUT to 85258 for Shout.</span>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-inner">
+        <p>&copy; <span id="year"></span> YouStillMatter. Built with compassion to remind you that you are never alone.</p>
+        <div class="footer-links">
+          <a href="anxiety-awareness.html">Anxiety Support</a>
+          <a href="depression-hope.html">Hope Stories</a>
+          <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="app.html">Mobile App</a>
+          <a href="mailto:hello@youstillmatter.org">Contact</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const yearSpan = document.getElementById('year');
+      if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/depression-hope.html
+++ b/depression-hope.html
@@ -25,6 +25,7 @@
             <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
             <li><a href="depression-hope.html" aria-current="page">Depression & Hope Stories</a></li>
             <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+            <li><a href="app.html">Mobile App</a></li>
           </ul>
         </nav>
       </div>
@@ -117,6 +118,7 @@
           <a href="anxiety-awareness.html">Anxiety Support</a>
           <a href="depression-hope.html">Hope Stories</a>
           <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="app.html">Mobile App</a>
           <a href="mailto:hello@youstillmatter.org">Contact</a>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
             <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
             <li><a href="youth-mental-health.html">Youth Toolkit</a></li>
+            <li><a href="app.html">Mobile App</a></li>
           </ul>
         </nav>
       </div>
@@ -118,6 +119,7 @@
           <a href="anxiety-awareness.html">Anxiety Support</a>
           <a href="depression-hope.html">Hope Stories</a>
           <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="app.html">Mobile App</a>
           <a href="mailto:hello@youstillmatter.org">Contact</a>
         </div>
       </div>

--- a/youth-mental-health.html
+++ b/youth-mental-health.html
@@ -25,6 +25,7 @@
             <li><a href="anxiety-awareness.html">Anxiety Awareness</a></li>
             <li><a href="depression-hope.html">Depression & Hope Stories</a></li>
             <li><a href="youth-mental-health.html" aria-current="page">Youth Toolkit</a></li>
+            <li><a href="app.html">Mobile App</a></li>
           </ul>
         </nav>
       </div>
@@ -176,6 +177,7 @@
           <a href="anxiety-awareness.html">Anxiety Support</a>
           <a href="depression-hope.html">Hope Stories</a>
           <a href="youth-mental-health.html">Youth Toolkit</a>
+          <a href="app.html">Mobile App</a>
           <a href="mailto:hello@youstillmatter.org">Contact</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated app.html page introducing the YouStillMatter mobile app with calm tools and crisis resources messaging
- highlight key features, crisis support options, and waitlist call to action for the upcoming app release
- link the new page from the global navigation and footer across existing static pages

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d38114ca0c8333a81837f576192838